### PR TITLE
refactor: Extract redis repository

### DIFF
--- a/lib/sidekiq/pauzer/repository.rb
+++ b/lib/sidekiq/pauzer/repository.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  module Pauzer
+    class Repository
+      include Enumerable
+
+      REDIS_KEY = "sidekiq-pauzer"
+
+      # @overload each
+      #   @return [Enumerator<String>]
+      #
+      # @overload each(&block)
+      #   For a block { |queue_name| ... }
+      #   @yieldparam queue_name [String]
+      #   @return [self]
+      def each
+        return to_enum __method__ unless block_given?
+
+        redis_call("SMEMBERS", REDIS_KEY).each { yield _1.freeze }
+
+        self
+      end
+
+      # @param queue_name [#to_s]
+      # @return [void]
+      def add(queue_name)
+        redis_call("SADD", REDIS_KEY, queue_name.to_s)
+        nil
+      end
+
+      # @param queue_name [#to_s]
+      # @return [void]
+      def delete(queue_name)
+        redis_call("SREM", REDIS_KEY, queue_name.to_s)
+        nil
+      end
+
+      # @param name [#to_s]
+      # @return [void]
+      def include?(queue_name)
+        redis_call("SISMEMBER", REDIS_KEY, queue_name.to_s).positive?
+      end
+
+      private
+
+      def redis_call(...)
+        Sidekiq.redis { _1.call(...) }
+      end
+    end
+  end
+end

--- a/spec/lib/sidekiq/pauzer/patches/basic_fetch_spec.rb
+++ b/spec/lib/sidekiq/pauzer/patches/basic_fetch_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe Sidekiq::Pauzer::Patches::BasicFetch do
   let(:queues) { ["foo,1", "bar,10", "baz,100"] }
 
   before do
-    Sidekiq::Pauzer.pause!(:foo)
+    Sidekiq::Pauzer.pause!("foo")
+    Sidekiq::Pauzer.configure { |c| c.refresh_rate = 0.1 }
+    Sidekiq::Pauzer.startup
+    sleep 0.1
+
     stub_const("Sidekiq::BasicFetch::TIMEOUT", 0.1)
   end
 

--- a/spec/lib/sidekiq/pauzer/patches/queue_spec.rb
+++ b/spec/lib/sidekiq/pauzer/patches/queue_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Sidekiq::Pauzer::Patches::Queue do
       Sidekiq::Pauzer.unpause!("foo")
 
       expect { subject }
-        .to change { redis_smembers(Sidekiq::Pauzer::REDIS_KEY) }.to(contain_exactly("foo"))
+        .to change { redis_smembers }.to(contain_exactly("foo"))
         .and change { Sidekiq::Pauzer.paused? "foo" }.to(true)
     end
   end
@@ -60,7 +60,7 @@ RSpec.describe Sidekiq::Pauzer::Patches::Queue do
       Sidekiq::Pauzer.pause!("foo")
 
       expect { subject }
-        .to change { redis_smembers(Sidekiq::Pauzer::REDIS_KEY) }.to(be_empty)
+        .to change { redis_smembers }.to(be_empty)
         .and change { Sidekiq::Pauzer.paused? "foo" }.to(false)
     end
   end

--- a/spec/lib/sidekiq/pauzer/repository_spec.rb
+++ b/spec/lib/sidekiq/pauzer/repository_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.describe Sidekiq::Pauzer::Repository do
+  subject(:repository) { described_class.new }
+
+  it { is_expected.to be_an Enumerable }
+
+  describe "#each" do
+    subject { repository.each { |inhibitor| yielded_results << inhibitor } }
+
+    let(:yielded_results) { [] }
+
+    before do
+      redis_sadd("a")
+      redis_sadd("b")
+      redis_sadd("c")
+    end
+
+    it { is_expected.to be repository }
+
+    it "yields each paused queue" do
+      expect { subject }.to(change { yielded_results }.to(contain_exactly("a", "b", "c")))
+    end
+
+    context "without block given" do
+      subject { repository.each }
+
+      it { is_expected.to be_an Enumerator }
+
+      it "returns each valid inhibitor" do
+        expect(subject).to contain_exactly("a", "b", "c")
+      end
+    end
+  end
+
+  describe "#add" do
+    before do
+      redis_sadd("a")
+      redis_sadd("b")
+    end
+
+    it "adds paused queue to redis" do
+      expect { repository.add("c") }.to(
+        change { redis_smembers }.to(contain_exactly("a", "b", "c"))
+      )
+    end
+
+    context "when given queue is already in the paused list" do
+      it "does nothing" do
+        expect { repository.add("b") }.to(keep_unchanged { redis_smembers })
+      end
+    end
+  end
+
+  describe "#delete" do
+    subject { repository.delete("b") }
+
+    before do
+      redis_sadd("a")
+      redis_sadd("b")
+    end
+
+    it "removes paused queue" do
+      expect { subject }.to(change { redis_smembers }.to(contain_exactly("a")))
+    end
+
+    context "when queue is not paused" do
+      subject { repository.delete("deadbeef") }
+
+      it "does nothing" do
+        expect { subject }.to(keep_unchanged { redis_smembers })
+      end
+    end
+  end
+
+  describe "#include?" do
+    subject { repository.include?("a") }
+
+    it { is_expected.to be false }
+
+    context "when given queue name is in the paused queues list" do
+      before { redis_sadd("a") }
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/lib/sidekiq/pauzer/web_spec.rb
+++ b/spec/lib/sidekiq/pauzer/web_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe Sidekiq::Pauzer::Web do
     it "allows pausing queues" do
       post "/queues/foo", "pause" => "1", "authenticity_token" => csrf_token
       expect(last_response.status).to eq 302
-      expect(redis_smembers(Sidekiq::Pauzer::REDIS_KEY)).to contain_exactly("foo")
-      expect(Sidekiq::Pauzer.paused_queues).to contain_exactly("foo")
+      expect(Sidekiq::Pauzer.paused?("foo")).to be true
+      expect(Sidekiq::Pauzer.paused?("bar")).to be false
 
       post "/queues/bar", "pause" => "1", "authenticity_token" => csrf_token
       expect(last_response.status).to eq 302
-      expect(redis_smembers(Sidekiq::Pauzer::REDIS_KEY)).to contain_exactly("foo", "bar")
-      expect(Sidekiq::Pauzer.paused_queues).to contain_exactly("foo", "bar")
+      expect(Sidekiq::Pauzer.paused?("foo")).to be true
+      expect(Sidekiq::Pauzer.paused?("bar")).to be true
     end
 
     it "allows unpausing queues" do
@@ -51,13 +51,13 @@ RSpec.describe Sidekiq::Pauzer::Web do
 
       post "/queues/foo", "unpause" => "1", "authenticity_token" => csrf_token
       expect(last_response.status).to eq 302
-      expect(redis_smembers(Sidekiq::Pauzer::REDIS_KEY)).to contain_exactly("bar")
-      expect(Sidekiq::Pauzer.paused_queues).to contain_exactly("bar")
+      expect(Sidekiq::Pauzer.paused?("foo")).to be false
+      expect(Sidekiq::Pauzer.paused?("bar")).to be true
 
       post "/queues/bar", "unpause" => "1", "authenticity_token" => csrf_token
       expect(last_response.status).to eq 302
-      expect(redis_smembers(Sidekiq::Pauzer::REDIS_KEY)).to be_empty
-      expect(Sidekiq::Pauzer.paused_queues).to be_empty
+      expect(Sidekiq::Pauzer.paused?("foo")).to be false
+      expect(Sidekiq::Pauzer.paused?("bar")).to be false
     end
 
     it "allows clearing the queue" do

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -16,12 +16,12 @@ module PauzerTestingContext
     Sidekiq.default_configuration.default_capsule.fire_event(...)
   end
 
-  def redis_smembers(key)
-    Sidekiq.redis { |conn| conn.call("SMEMBERS", key) }
+  def redis_smembers
+    Sidekiq.redis { |conn| conn.call("SMEMBERS", "sidekiq-pauzer") }
   end
 
-  def redis_sadd(key, value)
-    Sidekiq.redis { |conn| conn.call("SADD", key, value) }
+  def redis_sadd(value)
+    Sidekiq.redis { |conn| conn.call("SADD", "sidekiq-pauzer", value) }
   end
 end
 


### PR DESCRIPTION
Leave Queues with single responsibility - track eventually-consistent list of paused queues.